### PR TITLE
✨ feat: implement dark mode

### DIFF
--- a/knutice/src/app/notice/page.tsx
+++ b/knutice/src/app/notice/page.tsx
@@ -1,13 +1,20 @@
 'use client';
 
+import { ThemeProvider } from 'styled-components';
+import useTheme from '@/hooks/useTheme';
 import { Navbar, Home, MainContent } from '@/components';
+import { THEME } from '@/styles/theme';
 
 const Notice = () => {
+  const { isDarkMode, switchTheme } = useTheme();
+
   return (
-    <Home>
-      <Navbar />
-      <MainContent />
-    </Home>
+    <ThemeProvider theme={isDarkMode ? THEME.dark : THEME.light}>
+      <Home>
+        <Navbar mode={isDarkMode} themeHandler={switchTheme} />
+        <MainContent />
+      </Home>
+    </ThemeProvider>
   );
 };
 

--- a/knutice/src/app/page.tsx
+++ b/knutice/src/app/page.tsx
@@ -1,14 +1,22 @@
 'use client';
 
+import { ThemeProvider } from 'styled-components';
+
+import useTheme from '@/hooks/useTheme';
+import { THEME } from '@/styles/theme';
 import { Navbar, Home, FirstSection, SecondSection } from '@/components';
 
 const Main = () => {
+  const { isDarkMode, switchTheme } = useTheme();
+
   return (
-    <Home>
-      <Navbar />
-      <FirstSection />
-      <SecondSection />
-    </Home>
+    <ThemeProvider theme={isDarkMode ? THEME.dark : THEME.light}>
+      <Home>
+        <Navbar mode={isDarkMode} themeHandler={switchTheme} />
+        <FirstSection />
+        <SecondSection />
+      </Home>
+    </ThemeProvider>
   );
 };
 

--- a/knutice/src/components/Common/Navbar.tsx
+++ b/knutice/src/components/Common/Navbar.tsx
@@ -15,7 +15,7 @@ const Navbar = () => {
     <NavContainer>
       <Header>
         <LogoWrapper>
-          <Logo>KNUTICE</Logo>
+          <Logo href="/">KNUTICE</Logo>
         </LogoWrapper>
         <ItemWrapper>
           <Link href="/">

--- a/knutice/src/components/Common/Navbar.tsx
+++ b/knutice/src/components/Common/Navbar.tsx
@@ -10,7 +10,12 @@ import {
 } from '@/styles/Navbar/Navbar';
 import Link from 'next/link';
 
-const Navbar = () => {
+interface INavbar {
+  mode: boolean;
+  themeHandler: () => void;
+}
+
+const Navbar = ({ mode, themeHandler }: INavbar) => {
   return (
     <NavContainer>
       <Header>
@@ -29,7 +34,23 @@ const Navbar = () => {
             </Item>
           </Link>
           <Item>
-            <Image src="/assets/sun.png" alt="" width={22} height={22} />
+            {mode ? (
+              <Image
+                src="/assets/sun.png"
+                alt="sun icon"
+                width={22}
+                height={22}
+                onClick={themeHandler}
+              />
+            ) : (
+              <Image
+                src="/assets/moon.png"
+                alt="moon icon"
+                width={22}
+                height={22}
+                onClick={themeHandler}
+              />
+            )}
           </Item>
         </ItemWrapper>
       </Header>

--- a/knutice/src/components/Common/Navbar.tsx
+++ b/knutice/src/components/Common/Navbar.tsx
@@ -15,12 +15,6 @@ const Navbar = () => {
     <NavContainer>
       <Header>
         <LogoWrapper>
-          <img
-            src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Objects/Bell.png"
-            alt="Bell"
-            width="25"
-            height="25"
-          />
           <Logo>KNUTICE</Logo>
         </LogoWrapper>
         <ItemWrapper>

--- a/knutice/src/hooks/useTheme.ts
+++ b/knutice/src/hooks/useTheme.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react';
+
+const useTheme = () => {
+  const localTheme = localStorage.getItem('theme');
+  const [isDarkMode, setIsDarkMode] = useState(localTheme === 'dark' ? true : false);
+
+  const switchTheme = () => {
+    setIsDarkMode((prev) => {
+      const changeTheme = !prev;
+      localStorage.setItem('theme', changeTheme ? 'dark' : 'light');
+
+      return changeTheme;
+    });
+  };
+
+  return { isDarkMode, switchTheme };
+};
+
+export default useTheme;

--- a/knutice/src/styles/Home.ts
+++ b/knutice/src/styles/Home.ts
@@ -5,4 +5,6 @@ export const Container = styled.div`
   width: 100%;
   min-height: 100vh;
   background-color: ${({ theme }) => theme.backgroundColor};
+
+  transition: 0.3s linear;
 `;

--- a/knutice/src/styles/Home.ts
+++ b/knutice/src/styles/Home.ts
@@ -4,5 +4,5 @@ export const Container = styled.div`
   position: relative;
   width: 100%;
   min-height: 100vh;
-  background-color: #000;
+  background-color: ${({ theme }) => theme.backgroundColor};
 `;

--- a/knutice/src/styles/Main/FirstSection.ts
+++ b/knutice/src/styles/Main/FirstSection.ts
@@ -22,7 +22,7 @@ const TitleWrapper = styled.div`
 
 const Title = styled.h1`
   font-size: 5rem;
-  color: #e3e3e3;
+  color: ${({ theme }) => theme.color};
 `;
 
 const gradientAnimation = keyframes`

--- a/knutice/src/styles/Main/SecondSection.ts
+++ b/knutice/src/styles/Main/SecondSection.ts
@@ -36,13 +36,13 @@ const ContentDesc = styled.div`
 
 const Title = styled.h1<{ $align?: string }>`
   text-align: ${(props) => (props.$align ? props.$align : 'left')};
-  color: #fff;
+  color: ${({ theme }) => theme.color};
   font-size: 3.8rem;
   line-height: 1.2;
 `;
 
 const Description = styled.span`
-  color: #fff;
+  color: ${({ theme }) => theme.color};
   font-size: 1.25rem;
   line-height: 1.45;
   white-space: pre-line;
@@ -58,7 +58,7 @@ const Image = styled.div`
   width: 100%;
   height: 100%;
 
-  border: 2px solid #ffffffc8;
+  border: 2px solid ${({ theme }) => theme.borderColor};
   border-radius: 1.3rem;
 `;
 

--- a/knutice/src/styles/Navbar/Navbar.ts
+++ b/knutice/src/styles/Navbar/Navbar.ts
@@ -28,7 +28,6 @@ const LogoWrapper = styled.div`
   display: flex;
   align-items: center;
 
-  gap: 0.3rem;
   cursor: pointer;
 `;
 

--- a/knutice/src/styles/Navbar/Navbar.ts
+++ b/knutice/src/styles/Navbar/Navbar.ts
@@ -6,11 +6,11 @@ const NavContainer = styled.div`
   width: 100%;
   height: 5rem;
 
-  border-bottom: 1px solid #2f2f2f;
-  background-color: #000;
-  color: #fff;
+  border-bottom: 1px solid ${({ theme }) => theme.borderBottom};
+  background-color: ${({ theme }) => theme.backgroundColor};
 
   z-index: 3;
+  transition: 0.3s linear;
 `;
 
 const Header = styled.div`
@@ -36,7 +36,7 @@ const Logo = styled.a`
   font-size: 1.5rem;
   font-weight: 500;
 
-  color: #fff;
+  color: ${({ theme }) => theme.color};
 `;
 
 const ItemWrapper = styled.div`
@@ -54,7 +54,7 @@ const Label = styled.span`
   font-size: 1.25rem;
   font-weight: 500;
 
-  color: #fff;
+  color: ${({ theme }) => theme.color};
 `;
 
 export { NavContainer, Header, LogoWrapper, Logo, Label, ItemWrapper, Item };

--- a/knutice/src/styles/Navbar/Navbar.ts
+++ b/knutice/src/styles/Navbar/Navbar.ts
@@ -31,7 +31,8 @@ const LogoWrapper = styled.div`
   cursor: pointer;
 `;
 
-const Logo = styled.span`
+const Logo = styled.a`
+  text-decoration: none;
   font-size: 1.5rem;
   font-weight: 500;
 

--- a/knutice/src/styles/Notice/NoticeList.ts
+++ b/knutice/src/styles/Notice/NoticeList.ts
@@ -13,6 +13,7 @@ const CardWrapper = styled.li`
   width: 390px;
   padding: 0 0.8rem;
 
+  list-style: none;
   transition: transform 0.25s ease-in;
   transform: translateY(0);
 
@@ -27,13 +28,13 @@ const LinkItem = styled.a`
 
 const CardItem = styled.div`
   position: relative;
-
   margin-top: 1.6rem;
 
   border-radius: 14px;
-
-  background-color: #222224;
-  box-shadow: 4px 12px 30px 6px rgba(0, 0, 0, 0.09);
+  box-shadow:
+    0 0.5rem 0.5rem 0 rgba(0, 0, 0, 0.03),
+    0 1rem 1rem 0 rgba(0, 0, 0, 0.03);
+  background: ${({ theme }) => theme.cardItemBg};
 `;
 
 const Notice = styled.div`
@@ -54,12 +55,12 @@ const Title = styled.h2`
   white-space: nowrap;
   overflow: hidden;
 
-  color: #fff;
+  color: ${({ theme }) => theme.color};
 `;
 
 const Department = styled.span`
-  color: #fff;
   font-weight: 400;
+  color: ${({ theme }) => theme.color};
 `;
 
 const Classification = styled.span`

--- a/knutice/src/styles/Notice/Tabs.ts
+++ b/knutice/src/styles/Notice/Tabs.ts
@@ -15,16 +15,17 @@ const Item = styled.a<{ $isSelected: boolean }>`
   padding: 0.9rem 1.5rem;
   border-radius: 1.875rem;
 
-  color: ${(props) => (props.$isSelected ? '#000' : '#FFF')};
   font-size: 1.3rem;
-  font-weight: 500;
+  font-weight: 400;
   text-decoration: none;
 
-  background: ${(props) => (props.$isSelected ? '#FFF' : '#333333')};
+  color: ${({ $isSelected, theme }) => ($isSelected ? theme.selectedTabColor : theme.color)};
+  background: ${({ $isSelected, theme }) => ($isSelected ? theme.selectedTabBg : theme.tabBgColor)};
 
   &:hover {
-    color: #000;
-    background: #fff;
+    color: ${({ theme }) => theme.selectedTabColor};
+    background: ${({ theme }) => theme.selectedTabBg};
+
     transition: 0.5s;
   }
 `;

--- a/knutice/src/styles/Notice/Title.ts
+++ b/knutice/src/styles/Notice/Title.ts
@@ -12,17 +12,17 @@ const TitleText = styled.h1`
   display: flex;
   align-items: center;
 
-  color: #fff;
   font-size: 2.8rem;
+  color: ${({ theme }) => theme.color};
 
   gap: 0.5rem;
 `;
 
 const Description = styled.span`
-  color: #fff;
   font-size: 2rem;
   font-weight: 500;
   text-indent: 0.2rem;
+  color: ${({ theme }) => theme.color};
 `;
 
 export { TitleContainer, TitleText, Description };

--- a/knutice/src/styles/theme.ts
+++ b/knutice/src/styles/theme.ts
@@ -1,0 +1,45 @@
+export const THEME = {
+  dark: {
+    backgroundColor: '#000',
+
+    // Main
+    color: '#e3e3e3',
+    borderColor: '#ffffffc8',
+
+    // Navbar
+    borderBottom: '#2f2f2f',
+
+    // NoticeList
+    cardItemBg: '#222224',
+
+    // Tabs
+    tabFontColor: '#000',
+    tabBgColor: '#333333',
+
+    hoverTabBg: '#eee',
+
+    selectedTabBg: '#eee',
+    selectedTabColor: '#000',
+  },
+
+  light: {
+    backgroundColor: '#fff',
+
+    // Main
+    color: '#000',
+    borderColor: '#2f2f2f',
+
+    // Navbar
+    borderBottom: '#eee',
+
+    // NoticeList
+    cardItemBg: '#fff',
+
+    // Tabs
+    tabFontColor: '#000',
+    tabBgColor: '#eee',
+
+    selectedTabBg: '#000',
+    selectedTabColor: '#e3e3e3',
+  },
+};


### PR DESCRIPTION
## 📢 기능 소개
> 사용자가 서비스의 테마를 선택할 수 있도록 다크 모드를 구현한다.

## ✨ 작업 상세 내용

- [x] dark mode custom hook 구현 (`useTheme.ts`)
- [x] `Theme`에 각 테마별 색상 코드 추가 
- [x] `Navbar` 테마 아이콘 클릭 시마다 해당하는 테마의 아이콘으로 변경되도록 구현 (해: light, 달: dark) 
- [x] 모든 페이지에 다크 모드 적용

## 📺 구현 화면
![knutice-darkmode](https://github.com/FX-PR0JECT/KNUTICE-CLIENT/assets/106158901/605e6d63-e600-473c-8840-bc9eb5f05523)

issue: #14 