### PR TITLE
✨ feat: implement infinite scroll in notice page

### DIFF
--- a/knutice/src/components/Notice/NoticeList.tsx
+++ b/knutice/src/components/Notice/NoticeList.tsx
@@ -16,6 +16,7 @@ import {
   NoticeCardList,
 } from '@/styles/Notice/NoticeList';
 import { ContentImage } from '@/components';
+import { departmentTag } from '@/utils/departmentTag';
 
 interface INotice {
   departName: string;
@@ -74,12 +75,6 @@ const NoticeList = () => {
 };
 
 const NoticeCard = ({ notice, selectedTab }: INoticeCard) => {
-  const department = (selectedTab: string) => {
-    if (selectedTab === 'general') return '#일반소식 #general';
-    if (selectedTab === 'event') return '#행사안내 #event';
-    if (selectedTab === 'scholarship') return '#장학안내 #scholarship';
-    if (selectedTab === 'academic') return '#학사공지사항 #acadmic';
-  };
 
   return (
     <CardWrapper>
@@ -89,7 +84,7 @@ const NoticeCard = ({ notice, selectedTab }: INoticeCard) => {
           <Notice>
             <Title>{notice.title}</Title>
             <Department>{notice.departName}</Department>
-            <Classification>{department(selectedTab)}</Classification>
+            <Classification>{departmentTag(selectedTab)}</Classification>
             <RegistrationDate>{notice.registrationDate}</RegistrationDate>
           </Notice>
         </CardItem>

--- a/knutice/src/utils/departmentTag.ts
+++ b/knutice/src/utils/departmentTag.ts
@@ -1,0 +1,6 @@
+export const departmentTag = (selectedTab: string) => {
+  if (selectedTab === 'general') return '#일반소식 #general';
+  if (selectedTab === 'event') return '#행사안내 #event';
+  if (selectedTab === 'scholarship') return '#장학안내 #scholarship';
+  if (selectedTab === 'academic') return '#학사공지사항 #academic';
+};


### PR DESCRIPTION
## 📢 기능 소개
>  사용자가 공지 페이지의 모든 공지를 스크롤만 해도 쉽게 확인 가능하도록 무한 스크롤을 구현 및 적용한다.

## ✨ 작업 상세 내용

- [x] 부서별 태그 유틸 함수 분리
- [x] 공지 페이지 무한 스크롤 구현

## 📺 구현 화면
![infinite-scroll](https://github.com/FX-PR0JECT/KNUTICE-CLIENT/assets/106158901/f2196117-1bed-4a3b-a44b-3b0cdd593a67)

issue: #13 